### PR TITLE
Handle strings in Asciinema parameters

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -5,6 +5,9 @@ def value_str(value):
     s = str(value)
     if isinstance(value, bool):
         s = s.lower()
+        return s
+    if isinstance(value, str):
+        return '"' + s + '"'
     return s
 
 def define_env(env):


### PR DESCRIPTION
Without this when passing string values, we need to double quote and escape string values.  

Before: `asciinema("cast/source/s3demo.cast", theme="\"nord\"")`
After: `asciinema("cast/source/s3demo.cast", theme="nord")`
